### PR TITLE
Addition of verify_ssl to .yaml Unifi documentation.

### DIFF
--- a/source/_components/device_tracker.unifi.markdown
+++ b/source/_components/device_tracker.unifi.markdown
@@ -31,6 +31,7 @@ Configuration variables:
 - **port** (*Optional*): The port of your controller's web interface. Defaults to `8443`.
 - **username** (*Required*: The username of an user with administrative privileges, usually `admin`.
 - **password** (*Required*): The password for your given admin account.
+- **verify_ssl** (*Optional*):  Verify the controllers SSL certificate.  Defaults to True however can also be False or "path/to/custom_cert.pem".
 - **site_id** (*Optional*): Allows you to specify a `site_id` for device tracking. Defaults to `default`. Found in the URL of the controller (i.e. https://CONTROLLER:PORT/manage/site/SITE_ID/dashboard)
 
 See the [device tracker component page](/components/device_tracker/) for instructions how to configure the people to be tracked.


### PR DESCRIPTION
Added new optional configuration to documentation.


**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

